### PR TITLE
Install h2 package for http2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
 pydantic==2.9.2
-httpx==0.27.2
+httpx[http2]==0.27.2
 python-dotenv==1.0.1
 python-multipart==0.0.12


### PR DESCRIPTION
Update httpx dependency to `httpx[http2]` to resolve the 'Missing h2 package' error for HTTP/2 support.

---
<a href="https://cursor.com/background-agent?bcId=bc-e26913c5-ebbc-4037-9cae-834164b65c88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e26913c5-ebbc-4037-9cae-834164b65c88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

